### PR TITLE
Fixed the switching of the month day issue when saving places.

### DIFF
--- a/app/controllers/places_controller.rb
+++ b/app/controllers/places_controller.rb
@@ -22,7 +22,10 @@ class PlacesController < ApplicationController
   # POST /places
   # POST /places.json
   def create
-    @place = Place.new(place_params)
+    # Modify the used param so ruby knows how to interpret it
+    params = place_params
+    params[:used] = DateTime.strptime(params[:used], '%m/%d/%Y')
+    @place = Place.new(params)
 
     # @place.used = @place.used.to_datetimed
 


### PR DESCRIPTION
Seems like ruby wants a string in the format of d/m/Y (thus why the day month values would be switched on saved dates) so this changes the param to that so it will be saved appropriately. As long as the param is sent as a m/d/Y this code will work. This could also be done on the jquery side if that is more preferable. 